### PR TITLE
luarocks_dependency: Added serpent current version to rockspec.template

### DIFF
--- a/rockspec.template
+++ b/rockspec.template
@@ -20,6 +20,7 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
+   "serpent >= 0.28-1",
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
 faketorio/src/faketorio.lua line 9
> faketorio.world.serpent = require("serpent")

It would be nice if luarocks automatically installed this when installing faketorio with 
> luarocks install faketorio

since the base code depends on it

I haven't checked that this exact command works (not sure if I'm allowed to upload to luarocks), but it looks right, when compared to 
https://github.com/luarocks/luarocks/wiki/Rockspec-format
https://luarocks.org/modules/paulclinger/serpent/0.28-1
https://github.com/Olivine-Labs/busted/blob/master/busted-2.0.rc12-1.rockspec